### PR TITLE
Add support for passing complete policy json documents into the encrypted bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ module "encrypted_bucket" {
 |------------------------|---------------------------------------------------------------------------------------------------------------------|:------------:|:--------:|
 | bucket_name            | The name to use for the encrypted S3 bucket                                                                         | -            | yes      |
 | bucket_policy_template | A template for the policy to apply to the bucket                                                                    | see policies | no       |
+| source_policy_json     | A source policy for the bucket, additional statements to enable encryption will be added to the policy              | ""           | no       |
 | acl                    | The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply.            | private      | no       |
 | mfa_delete             | Enable MFA delete for either _Change the versioning state of your bucket_ or _Permanently delete an object version_ | false        | no       |
 | tags                   | A map of additional tags to set on the bucket                                                                       | {}           | no       |
@@ -32,10 +33,14 @@ module "encrypted_bucket" {
 
 By default, a bucket policy that enforces encrypted inflight operations and 
 object uploads is applied to the bucket. In the case that further statements
-need to be applied, a `bucket_policy_template` can be provided that will
-receive `deny_unencrypted_object_upload_fragment` and 
-`deny_unencrypted_inflight_operations_fragment` statement fragments along with
-the `bucket_name` and the resulting policy will be used instead.
+need to be applied, there are two methods that can be used:
+- A `bucket_policy_template` can be provided that will receive
+  `deny_unencrypted_object_upload_fragment` and
+  `deny_unencrypted_inflight_operations_fragment`
+  statement fragments along with the `bucket_name` and the resulting policy
+  will be used instead.
+- A `source_policy_json` can be provided and the additional statements will
+  be added to this policy before being attached to the bucket
 
 The provided `tags` map, when present will be merged with a compulsory tags map 
 containing a `Name` tag equal to the bucket name.

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -8,4 +8,6 @@ configuration_directory: "%{hiera('work_directory')}/%{hiera('source_directory')
 
 acl: "private"
 
+include_source_policy_json: "false"
+
 mfa_delete: "false"

--- a/config/roles/harness.yaml
+++ b/config/roles/harness.yaml
@@ -8,5 +8,7 @@ vars:
 
   acl: "%{hiera('acl')}"
 
+  include_source_policy_json: "%{hiera('include_source_policy_json')}"
+
   mfa_delete: "%{hiera('mfa_delete')}"
 

--- a/main.tf
+++ b/main.tf
@@ -37,7 +37,12 @@ resource "aws_s3_bucket" "encrypted_bucket" {
   tags = merge(map("Name", var.bucket_name), var.tags)
 }
 
+data "aws_iam_policy_document" "encrypted_bucket_policy_document" {
+  source_json = var.source_policy_json
+  override_json = data.template_file.encrypted_bucket_policy.rendered
+}
+
 resource "aws_s3_bucket_policy" "encrypted_bucket" {
   bucket = aws_s3_bucket.encrypted_bucket.id
-  policy = data.template_file.encrypted_bucket_policy.rendered
+  policy = data.aws_iam_policy_document.encrypted_bucket_policy_document.json
 }

--- a/spec/infra/harness/main.tf
+++ b/spec/infra/harness/main.tf
@@ -1,3 +1,11 @@
+data "template_file" "test_policy" {
+  template = file("${path.module}/resources/test-policy.json.tpl")
+
+  vars = {
+    bucket_name = var.bucket_name
+  }
+}
+
 module "encrypted_bucket" {
   source = "../../../../"
 
@@ -5,6 +13,8 @@ module "encrypted_bucket" {
   acl = var.acl
 
   mfa_delete = var.mfa_delete
+
+  source_policy_json = var.include_source_policy_json ? data.template_file.test_policy.rendered : ""
 
   tags = {
     Thing = "value"

--- a/spec/infra/harness/resources/test-policy.json.tpl
+++ b/spec/infra/harness/resources/test-policy.json.tpl
@@ -1,0 +1,15 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "TestPolicy",
+      "Effect": "Deny",
+      "Principal": "*",
+      "Action": "s3:*",
+      "Resource": "arn:aws:s3:::${bucket_name}/*",
+      "Condition": {
+        "IpAddress": {"aws:SourceIp": "8.8.8.8/32"}
+      }
+    }
+  ]
+}

--- a/spec/infra/harness/variables.tf
+++ b/spec/infra/harness/variables.tf
@@ -3,3 +3,5 @@ variable "bucket_name" {}
 variable "mfa_delete" {}
 
 variable "acl" {}
+
+variable "include_source_policy_json" {}

--- a/variables.tf
+++ b/variables.tf
@@ -6,6 +6,11 @@ variable "bucket_policy_template" {
   description = "A template for the policy to apply to the bucket."
   default = ""
 }
+variable "source_policy_json" {
+  description = "A source policy for the bucket, additional statements to enable encryption will be added to the policy"
+  default = ""
+}
+
 variable "acl" {
   description = "The canned ACL to apply. Defaults to private."
   default = "private"


### PR DESCRIPTION
This PR uses the `source_json` and `override_json` properties in
`aws_iam_policy_document` resources. By passing a variable that contains
a complete policy document json in as the `source_json` and the internal
rendered policy as the `override_json`, terraform can automatically merge
the policy's statements without needing to provide a template to customise
the policy