### PR TITLE
Add Bucket Access Logging. Authors: @claudiodavid-ai @KishanAnjanaKha…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
   `var.public_access_block`. See the [inputs section in the README](https://github.com/infrablocks/terraform-aws-encrypted-bucket#inputs)
   or [Terraform registry entry](https://registry.terraform.io/modules/infrablocks/encrypted-bucket/aws/latest) for more details.
   The extra permissions required are specified in [required permissions](https://github.com/infrablocks/terraform-aws-encrypted-bucket#required-permissions).
+* Access logging can be enabled with `var.enable_access_logging` (this will also creates a new bucket for the access logs). 
+  To change the default name of the access bucket(`<bucket-name>-access-log`) use `var.access_log_bucket_name`. This is off by default.
+* [S3 Bucket Keys](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucket-key.html) can be enabled (when encryption is set to kms)
+  by configuring `var.bucket_key_enabled`. This is off by default.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ for more details.
 | source_policy_json                          | A source policy for the bucket, additional statements to enable encryption will be added to the policy              |      ""      |    no    |
 | acl                                         | The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply.            |   private    |    no    |
 | mfa_delete                                  | Enable MFA delete for either _Change the versioning state of your bucket_ or _Permanently delete an object version_ |    false     |    no    |
-| enable_access_logging  | Enable access logging for the bucket. Also creates the logging bucket                                                                    | no           | no       |
+| enable_access_logging                       | Enable access logging for the bucket. Also creates the logging bucket                                               | no           | no       |
+| bucket_key_enabled                          | Whether or not to use [S3 Bucket Keys](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucket-key.html)       | false        | no       |
 | tags                                        | A map of additional tags to set on the bucket                                                                       |      {}      |    no    |
 | public_access_block                         | An object of public access block settings to apply to the bucket                                                    |  see below   |    no    |
 | public_access_block.block_public_acls       | Whether to block public ACLs                                                                                        |    false     |    no    |

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ for more details.
 | acl                                         | The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply.            |   private    |    no    |
 | mfa_delete                                  | Enable MFA delete for either _Change the versioning state of your bucket_ or _Permanently delete an object version_ |    false     |    no    |
 | enable_access_logging                       | Enable access logging for the bucket. Also creates the logging bucket                                               | no           | no       |
+| access_log_bucket_name                      | When access logging is enabled this allows you to customise the name of the access log bucket.                      | "-access-log"|  no      |
 | bucket_key_enabled                          | Whether or not to use [S3 Bucket Keys](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucket-key.html)       | false        | no       |
 | tags                                        | A map of additional tags to set on the bucket                                                                       |      {}      |    no    |
 | public_access_block                         | An object of public access block settings to apply to the bucket                                                    |  see below   |    no    |

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ for more details.
 | source_policy_json                          | A source policy for the bucket, additional statements to enable encryption will be added to the policy              |      ""      |    no    |
 | acl                                         | The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply.            |   private    |    no    |
 | mfa_delete                                  | Enable MFA delete for either _Change the versioning state of your bucket_ or _Permanently delete an object version_ |    false     |    no    |
+| enable_access_logging  | Enable access logging for the bucket. Also creates the logging bucket                                                                    | no           | no       |
 | tags                                        | A map of additional tags to set on the bucket                                                                       |      {}      |    no    |
 | public_access_block                         | An object of public access block settings to apply to the bucket                                                    |  see below   |    no    |
 | public_access_block.block_public_acls       | Whether to block public ACLs                                                                                        |    false     |    no    |

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -11,6 +11,7 @@ acl: "private"
 include_source_policy_json: "false"
 
 mfa_delete: "false"
+enable_access_logging: "no"
 
 allow_destroy_when_objects_present: "no"
 

--- a/config/roles/harness.yaml
+++ b/config/roles/harness.yaml
@@ -11,6 +11,7 @@ vars:
   include_source_policy_json: "%{hiera('include_source_policy_json')}"
 
   mfa_delete: "%{hiera('mfa_delete')}"
+  enable_access_logging: "%{hiera('enable_access_logging')}"
 
   allow_destroy_when_objects_present: "%{hiera('allow_destroy_when_objects_present')}"
 

--- a/main.tf
+++ b/main.tf
@@ -26,7 +26,9 @@ locals {
 }
 
 resource "aws_s3_bucket" "access_log_bucket" {
-  bucket = "${var.bucket_name}-access-log"
+  bucket = var.access_log_bucket_name != null
+    ? var.access_log_bucket_name
+    : "${var.bucket_name}-access-log"
   acl    = "log-delivery-write"
   count = var.enable_access_logging == "yes" ? 1 : 0
 

--- a/main.tf
+++ b/main.tf
@@ -25,10 +25,29 @@ locals {
   )
 }
 
-resource "aws_s3_bucket" "access_log_bucket" {
-  bucket = (var.access_log_bucket_name != null
+locals {
+  access_bucket_name = (var.access_log_bucket_name != null
   ? var.access_log_bucket_name
   : "${var.bucket_name}-access-log")
+}
+data "template_file" "deny_unencrypted_inflight_operations_fragment_access_bucket" {
+  template = file("${path.module}/policy-fragments/deny-unencrypted-inflight-operations.json.tpl")
+  vars = {
+    bucket_name = local.access_bucket_name
+  }
+}
+
+data "template_file" "access_bucket_policy" {
+  template = file("${path.module}/policies/access-bucket-policy.json.tpl")
+
+  vars = {
+    bucket_name = local.access_bucket_name
+    deny_unencrypted_inflight_operations_fragment = data.template_file.deny_unencrypted_inflight_operations_fragment_access_bucket.rendered
+  }
+}
+
+resource "aws_s3_bucket" "access_log_bucket" {
+  bucket = local.access_bucket_name
   acl    = "log-delivery-write"
   count = var.enable_access_logging == "yes" ? 1 : 0
 
@@ -36,16 +55,13 @@ resource "aws_s3_bucket" "access_log_bucket" {
     enabled = false
   }
 
-  dynamic "server_side_encryption_configuration" {
-    for_each = var.kms_key_arn != null ? [1] : []
-    content {
-      rule {
-        apply_server_side_encryption_by_default {
-          kms_master_key_id = var.kms_key_arn
-          sse_algorithm = "aws:kms"
-        }
-        bucket_key_enabled = var.bucket_key_enabled
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        kms_master_key_id = var.kms_key_arn
+        sse_algorithm = local.sse_algorithm
       }
+      bucket_key_enabled = var.bucket_key_enabled
     }
   }
 
@@ -115,3 +131,16 @@ resource "aws_s3_bucket_public_access_block" "public_access_block" {
   ignore_public_acls = var.public_access_block.ignore_public_acls
   restrict_public_buckets = var.public_access_block.restrict_public_buckets
 }
+
+data "aws_iam_policy_document" "access_bucket_policy_document" {
+  source_json = var.source_policy_json
+  override_json = data.template_file.access_bucket_policy.rendered
+}
+
+resource "aws_s3_bucket_policy" "access_bucket" {
+  count = var.enable_access_logging == "yes" ? 1 : 0
+  bucket = aws_s3_bucket.access_log_bucket[0].id
+  policy = data.aws_iam_policy_document.access_bucket_policy_document.json
+}
+
+

--- a/main.tf
+++ b/main.tf
@@ -25,6 +25,32 @@ locals {
   )
 }
 
+resource "aws_s3_bucket" "access_log_bucket" {
+  bucket = "${var.bucket_name}-access-log"
+  acl    = "log-delivery-write"
+  count = var.enable_access_logging == "yes" ? 1 : 0
+
+  versioning {
+    enabled = false
+  }
+
+  dynamic "server_side_encryption_configuration" {
+    for_each = var.kms_key_arn != null ? [1] : []
+    content {
+      rule {
+        apply_server_side_encryption_by_default {
+          kms_master_key_id = var.kms_key_arn
+          sse_algorithm = "aws:kms"
+        }
+      }
+    }
+  }
+
+  tags = merge({
+    Name = var.bucket_name
+  }, var.tags)
+}
+
 resource "aws_s3_bucket" "encrypted_bucket" {
   bucket = var.bucket_name
 
@@ -38,6 +64,14 @@ resource "aws_s3_bucket" "encrypted_bucket" {
         kms_master_key_id = local.kms_master_key_id
         sse_algorithm = local.sse_algorithm
       }
+    }
+  }
+
+  dynamic logging {
+    for_each = var.enable_access_logging == "yes" ? [1] : []
+    content {
+      target_bucket = aws_s3_bucket.access_log_bucket[0].id
+      target_prefix = "log/"
     }
   }
 

--- a/main.tf
+++ b/main.tf
@@ -41,8 +41,8 @@ resource "aws_s3_bucket" "access_log_bucket" {
         apply_server_side_encryption_by_default {
           kms_master_key_id = var.kms_key_arn
           sse_algorithm = "aws:kms"
-          bucket_key_enabled = var.bucket_key_enabled
         }
+        bucket_key_enabled = var.bucket_key_enabled
       }
     }
   }
@@ -65,6 +65,7 @@ resource "aws_s3_bucket" "encrypted_bucket" {
         kms_master_key_id = local.kms_master_key_id
         sse_algorithm = local.sse_algorithm
       }
+      bucket_key_enabled = var.bucket_key_enabled
     }
   }
 

--- a/main.tf
+++ b/main.tf
@@ -41,6 +41,7 @@ resource "aws_s3_bucket" "access_log_bucket" {
         apply_server_side_encryption_by_default {
           kms_master_key_id = var.kms_key_arn
           sse_algorithm = "aws:kms"
+          bucket_key_enabled = var.bucket_key_enabled
         }
       }
     }

--- a/main.tf
+++ b/main.tf
@@ -26,9 +26,9 @@ locals {
 }
 
 resource "aws_s3_bucket" "access_log_bucket" {
-  bucket = var.access_log_bucket_name != null
-    ? var.access_log_bucket_name
-    : "${var.bucket_name}-access-log"
+  bucket = (var.access_log_bucket_name != null
+  ? var.access_log_bucket_name
+  : "${var.bucket_name}-access-log")
   acl    = "log-delivery-write"
   count = var.enable_access_logging == "yes" ? 1 : 0
 

--- a/policies/access-bucket-policy.json.tpl
+++ b/policies/access-bucket-policy.json.tpl
@@ -1,0 +1,6 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    ${deny_unencrypted_inflight_operations_fragment}
+  ]
+}

--- a/spec/bucket_spec.rb
+++ b/spec/bucket_spec.rb
@@ -253,7 +253,12 @@ describe 'Encrypted bucket' do
     end
 
     it { should exist }
-    it { should have_logging_enabled(target_bucket: access_log_bucket_name, target_prefix: 'logs/') }
+
+    it "should have logging enabled" do
+        bucket_info = s3_client.get_bucket_logging({bucket: bucket_name})
+        expect(bucket_info.logging_enabled.target_bucket).to(eq(access_log_bucket_name))
+        expect(bucket_info.logging_enabled.target_prefix).to(eq('log/'))
+    end
 
     describe 'access log bucket created' do
      subject { s3_bucket(access_log_bucket_name) }

--- a/spec/bucket_spec.rb
+++ b/spec/bucket_spec.rb
@@ -5,6 +5,7 @@ require 'pp'
 describe 'Encrypted bucket' do
   let(:region) { vars.region }
   let(:bucket_name) { vars.bucket_name }
+  let(:access_log_bucket_name) { "#{vars.bucket_name}-access-log" }
 
   subject { s3_bucket(bucket_name) }
 
@@ -243,6 +244,20 @@ describe 'Encrypted bucket' do
 
       expect(pab_config.block_public_acls).to(eq(true))
       expect(pab_config.block_public_policy).to(eq(true))
+    end
+  end
+
+  context 'with access logging' do
+    before(:all) do
+      provision(enable_access_logging: "yes")
+    end
+
+    it { should exist }
+    it { should have_logging_enabled(target_bucket: access_log_bucket_name, target_prefix: 'logs/') }
+
+    describe 'access log bucket created' do
+     subject { s3_bucket(access_log_bucket_name) }
+     it { should exist }
     end
   end
 

--- a/spec/infra/harness/main.tf
+++ b/spec/infra/harness/main.tf
@@ -10,6 +10,7 @@ module "encrypted_bucket" {
   acl = var.acl
 
   mfa_delete = var.mfa_delete
+  enable_access_logging = var.enable_access_logging
 
   source_policy_json = var.include_source_policy_json ? local.test_policy : ""
 

--- a/spec/infra/harness/variables.tf
+++ b/spec/infra/harness/variables.tf
@@ -1,6 +1,7 @@
 variable "region" {}
 variable "bucket_name" {}
 variable "mfa_delete" {}
+variable "enable_access_logging" {}
 
 variable "acl" {}
 

--- a/variables.tf
+++ b/variables.tf
@@ -69,6 +69,8 @@ variable "bucket_key_enabled" {
 variable "access_log_bucket_name" {
   description = "(Optional) Access log bucket name, Otherwise \"-access-log\" appended to bucket_name."
   type = string
+  default = null
+
   validation {
     condition = (var.access_log_bucket_name == null
     ? true

--- a/variables.tf
+++ b/variables.tf
@@ -54,3 +54,9 @@ variable "public_access_block" {
     restrict_public_buckets = false
   }
 }
+
+variable "enable_access_logging" {
+  description = "Whether or not to enable access logging (\"yes\" or \"no\")."
+  type = string
+  default = "no"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -60,3 +60,8 @@ variable "enable_access_logging" {
   type = string
   default = "no"
 }
+
+variable "bucket_key_enabled" {
+  description = "Whether or not to use Amazon S3 Bucket Keys for SSE-KMS."
+  default = false
+}

--- a/variables.tf
+++ b/variables.tf
@@ -65,3 +65,13 @@ variable "bucket_key_enabled" {
   description = "Whether or not to use Amazon S3 Bucket Keys for SSE-KMS."
   default = false
 }
+
+variable "access_log_bucket_name" {
+  description = "(Optional) Access log bucket name, Otherwise \"-access-log\" appended to bucket_name."
+  type = string
+  validation {
+    condition     = length(var.access_log_bucket_name) < 63
+    error_message = "Expected length of bucket to be in the range (0 - 63)"
+  }
+}
+

--- a/variables.tf
+++ b/variables.tf
@@ -73,7 +73,7 @@ variable "access_log_bucket_name" {
     condition = (var.access_log_bucket_name == null
     ? true
     : length(var.access_log_bucket_name) < 63)
-    error_message = "Expected length of bucket to be in the range (0 - 63)"
+    error_message = "Expected length of bucket to be in the range (0 - 63)."
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -70,7 +70,9 @@ variable "access_log_bucket_name" {
   description = "(Optional) Access log bucket name, Otherwise \"-access-log\" appended to bucket_name."
   type = string
   validation {
-    condition     = length(var.access_log_bucket_name) < 63
+    condition = (var.access_log_bucket_name == null
+    ? true
+    : length(var.access_log_bucket_name) < 63)
     error_message = "Expected length of bucket to be in the range (0 - 63)"
   }
 }


### PR DESCRIPTION
We added access logging option for the encrypted bucket.
We have added a test assertions that's currently failing. We think it's a bug from the awspec library. Have you encounters this type of issue with the library before? I see there are 2 other asserts that are failing for mfa_delete and server_side_encryption.

How can we move forward with this change?